### PR TITLE
Release 2024-02-18

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   bump-version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    name: Bump version and create changelog
     runs-on: ubuntu-latest
-    name: "Bump version and create changelog"
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     steps:
-      - name: Check out
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,17 +10,16 @@ permissions:
 
 jobs:
   deploy:
+    name: Deploy package to PyPI
     runs-on: ubuntu-latest
     steps:
-      - name: Check out
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.x'
+        uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,27 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: name-tests-test
-        args: ["--pytest-test-first"]
+        args: ['--pytest-test-first']
         exclude: ^tests/helpers/
       - id: trailing-whitespace
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.35.0
+    rev: v4.2.2
     hooks:
       - id: commitizen
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
     hooks:
-      - id: black
+      - id: ruff
+        args: [ '--fix', '--select', 'I', '--select', 'F401', '--fix-only' ]
+      - id: ruff-format
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.5.0
+    rev: eb1df34
     hooks:
       - id: docformatter
-        # these can't be pulled directly from the config atm, not sure why
-        args: ["-i", "--wrap-summaries=88", "--wrap-descriptions=88",
-               "--pre-summary-newline", "--make-summary-multi-line"]
+        args: [ '-i', '--config', './pyproject.toml' ]
+        additional_dependencies: ['tomli']

--- a/cz_nhm.py
+++ b/cz_nhm.py
@@ -95,6 +95,12 @@ class NHMCz(BaseCommitizen):
         [(r'^.+!$', 'MAJOR')]
         + [(f'^{c.short_name}', c.bump_type) for c in change_types if c.bump_type]
     )
+    bump_map_major_version_zero = OrderedDict(
+        [
+            (pattern, bump_type.replace('MAJOR', 'MINOR'))
+            for pattern, bump_type in bump_map.items()
+        ]
+    )
     commit_parser = rf'^(?P<change_type>{"|".join([c.short_name for c in change_types if c.display_name])})(?:\((?P<scope>[^)\r\n]+)\))?: (?P<message>[^\n]+)'
     changelog_pattern = (
         rf'^({"|".join([c.short_name for c in change_types if c.display_name])})'

--- a/cz_nhm.py
+++ b/cz_nhm.py
@@ -1,11 +1,10 @@
 # !/usr/bin/env python
 # encoding: utf-8
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 
+from commitizen import defaults as cz_defaults
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.utils import multiple_line_breaker, required_validator
-from commitizen import defaults as cz_defaults
-from collections import OrderedDict
 
 # CHANGE TYPES =========================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 py-modules = ["cz_nhm"]
 
-[tool.black]
-line-length = 88
-skip_string_normalization = true
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.pylint]
 max-line-length = 88


### PR DESCRIPTION
Adds support for the `major_version_zero` flag, which allows packages to stay at v0 while in alpha.

Also updates pre-commit hooks, updates github actions, and switches from black to ruff, in line with our other projects.