### PR TITLE
Ignore package build commits

### DIFF
--- a/cz_nhm.py
+++ b/cz_nhm.py
@@ -215,3 +215,12 @@ class NHMCz(BaseCommitizen):
             r'( [^\n\r]+)'  # subject
             r'((\n\n.*)|(\s*))?$'
         )
+
+    def changelog_message_builder_hook(self, parsed_message, commit):
+        # ignore dist package build commits
+        if (
+            parsed_message['change_type'] == 'chore'
+            and parsed_message['scope'] == 'dist'
+        ):
+            return False
+        return parsed_message


### PR DESCRIPTION
e.g. `chore(dist): rebuild dist package`.

There can be quite a few of these in a single release, and they clutter up the changelog:

> ## v0.2.1 (2025-02-27)
> 
> ### Fix
>
> - ...
>
> ### Chores/Misc
>
> - build dist package
> - build dist package
> - build dist package