### PR TITLE
Implement info method

### DIFF
--- a/cz_nhm.py
+++ b/cz_nhm.py
@@ -216,6 +216,10 @@ class NHMCz(BaseCommitizen):
             r'((\n\n.*)|(\s*))?$'
         )
 
+    def info(self) -> str:
+        return ('Commit messages are in the conventional commits style, with a few '
+                'extra commit types available.')
+
     def changelog_message_builder_hook(self, parsed_message, commit):
         # ignore dist package build commits
         if (


### PR DESCRIPTION
Has been made abstract in commitizen 4.10, so it needs to be present (and preferably return something useful).